### PR TITLE
Fix/mime detection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+version 1.0.16
+  + improve MIME-type detection for 'application/CDFV2' compound files
+  + fix a couple of exceptions with no functional impact at the end
+    of adaption processing
+
 version 1.0.15
   + fix avReadResponse for multi-read replies, which could wrongly cause
     an abort

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ ELSE()
   MESSAGE(FATAL_ERROR "c++11 (or fallback c++0x) support is required to build the ecap adapter")
 ENDIF()
 
-SET(PACKAGE_VERSION "1.0.15")
+SET(PACKAGE_VERSION "1.0.16")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -DPACKAGE_VERSION=\\\"${PACKAGE_VERSION}\\\"")
 SET(MODDIR "${CMAKE_INSTALL_PREFIX}/libexec/squid/" CACHE PATH "Directory to install the eCAP adapater to.")
 SET(DOCDIR "${CMAKE_INSTALL_PREFIX}/share/doc/squid-ecap-av-${PACKAGE_VERSION}" CACHE PATH "Directory to install the documentation to.")

--- a/src/adapter_avscan_Xaction.h
+++ b/src/adapter_avscan_Xaction.h
@@ -192,8 +192,10 @@ private:
     int  avWriteCommand(const char *command);
     int  avWriteChunk(char *buf, ssize_t len);
     void processContent(void);
-    void checkFileType(libecap::Area area);
     void noteContentAvailable(void);
+    int matchMime(const char *mimetype);
+    int mimeCheckOnFinish();
+    bool isCompound(const char *mimetype);
     void cleanup(void);
     void log_result(void);
     bool abCheckFinished();
@@ -204,6 +206,7 @@ private:
     time_t startTime;
     time_t lastContent;
     bool mustscan;
+    bool scanMimeAgain;
     bool trickled;
     bool senderror;
     bool bypass;


### PR DESCRIPTION
defer checking of MIME type if application/CDFV2 is detected;
this is a workaround if the first couple of bytes yield either nothing
or a Microsoft compound binary `application/CDFV2` or
`application/CDFV2-corrupt`; if no match on these is found in the skipList
or blockList, MIME type detection is deferred to either the point where
the size limit for scans is reached or the file is retrieved completely

while not being a perfect solution, this should fix problems with
MIME blocking of files that fall into that MS compound file category and
cannot be matched using only part of the file

also prevent triggering exceptions that do not seem to have any
functional impact but are just plain ugly